### PR TITLE
prevent dispatch issues in SequenceParallel to improve performance

### DIFF
--- a/yunchang/comm/all_to_all.py
+++ b/yunchang/comm/all_to_all.py
@@ -171,7 +171,7 @@ def all_to_all_5D(
         # (P, seq_len/P, 3, bs, hc/P, hs) scatter seqlen -all2all-> (P, seq_len/P, 3, bs, hc/P, hs) scatter head
         if seq_world_size > 1:
             dist.all_to_all_single(output, input_t, group=group)
-            torch.cuda.synchronize()
+            # torch.cuda.synchronize()
         else:
             output = input_t
 
@@ -204,7 +204,7 @@ def all_to_all_5D(
         # (P, bs x hc/P, seqlen/P, hs) scatter seqlen -all2all-> (P, bs x seq_len/P, hc/P, hs) scatter head
         if seq_world_size > 1:
             dist.all_to_all_single(output, input_t, group=group)
-            torch.cuda.synchronize()
+            # torch.cuda.synchronize()
         else:
             output = input_t
 


### PR DESCRIPTION
The following changes could potentially improve the performance when using SequenceParallel in xDiT on different hardware.

1. Explicitly calling torch.cuda.synchronize breaks the dispatch process on host. Removing it allows the dispatch behavior to proceed without waiting for dist.all_to_all_single to complete.
2. torch.cuda.synchronize is unnecessary here, pytorch guarantees the synchronization between communicating stream and computing stream. It does no harm to comment out torch.cuda.sychronize() in this case.

Big thanks to @zzb610 and @cheng for the solid analysis on CogVideoX5b's performance and all the help during the experiments.