### PR TITLE
pytorch ring attention

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ local_out = usp_attn(
 ### 3.Test
 
 ```bash
+torchrun --nproc_per_node=4  --master_port=12346 test/test_hybrid_attn.py --sp_ulysses_degree 2 --seqlen 1024 --use_bwd
 torchrun --nproc_per_node 8 test/test_hybrid_qkvpacked_attn.py
 ```
 

--- a/test/test_hybrid_attn.py
+++ b/test/test_hybrid_attn.py
@@ -125,7 +125,8 @@ if __name__ == "__main__":
         local_k.requires_grad = True
         local_v.requires_grad = True
 
-    usp_attn = LongContextAttention(ring_impl_type=ring_impl_type, attn_type=FlashAttentionImpl.FA)
+    usp_attn = LongContextAttention(ring_impl_type=ring_impl_type, 
+                                    attn_type=FlashAttentionImpl.TORCH)
 
     if rank == 0:
         print("#" * 30)

--- a/test/test_hybrid_attn.py
+++ b/test/test_hybrid_attn.py
@@ -18,6 +18,9 @@ def parse_args():
                         help='whether to test backward pass (default: False)')
     parser.add_argument('--sp_ulysses_degree', type=int, default=None,
                       help='sp_ulysses_degree (default: world_size)')
+    parser.add_argument('--ring_impl_type', type=str, default='basic',
+                      choices=['basic', 'zigzag'],
+                      help='ring implementation type (default: basic)')
     return parser.parse_args()
 
 def log(msg, a, rank0_only=False):
@@ -66,7 +69,7 @@ if __name__ == "__main__":
     nheads = 32
     d = 1280 // 32
     dropout_p = 0
-    causal = True
+    causal = False
     deterministic = False
     
     use_bwd = args.use_bwd
@@ -74,7 +77,7 @@ if __name__ == "__main__":
     assert seqlen % world_size == 0
     assert d % 8 == 0
 
-    ring_impl_type = "basic"  # You can change this to "basic" or "zigzag" if needed
+    ring_impl_type = args.ring_impl_type
 
     # Prepare inputs
     q = torch.randn(

--- a/test/test_hybrid_attn.py
+++ b/test/test_hybrid_attn.py
@@ -1,5 +1,4 @@
 from yunchang import (
-    AsyncLongContextAttention,
     LongContextAttention,
     set_seq_parallel_pg,
     EXTRACT_FUNC_DICT
@@ -9,6 +8,17 @@ import torch.distributed as dist
 from flash_attn import flash_attn_func
 from yunchang.kernels import FlashAttentionImpl
 from test_utils import attention_ref
+import argparse
+
+def parse_args():
+    parser = argparse.ArgumentParser(description='Test hybrid attention with configurable sequence length')
+    parser.add_argument('--seqlen', type=int, default=1024,
+                      help='sequence length (default: 1024)')
+    parser.add_argument('--use_bwd', action='store_true',
+                        help='whether to test backward pass (default: False)')
+    parser.add_argument('--sp_ulysses_degree', type=int, default=None,
+                      help='sp_ulysses_degree (default: world_size)')
+    return parser.parse_args()
 
 def log(msg, a, rank0_only=False):
     world_size = dist.get_world_size()
@@ -38,26 +48,28 @@ def log(msg, a, rank0_only=False):
 # test it with:
 # torchrun --nproc_per_node=4  test/test_hybrid_attn.py
 if __name__ == "__main__":
-
+    args = parse_args()
+    
     torch.random.manual_seed(0)
-    use_bwd = True
+
     dist.init_process_group("nccl")
 
     rank = dist.get_rank()
     world_size = dist.get_world_size()
 
-    assert world_size == 4, f"torchrun --nproc_per_node=4  test/test_hybrid_attn.py"
     # Inference mainly uses fp16; ROCM flash attention with bf16 precision is slightly larger, will be fixed soon 
     dtype = torch.bfloat16
     device = torch.device(f"cuda:{rank}")
 
-    batch_size = 2
-    seqlen = 1024
-    nheads = 4
-    d = 128
+    batch_size = 1
+    seqlen = args.seqlen
+    nheads = 32
+    d = 1280 // 32
     dropout_p = 0
     causal = True
     deterministic = False
+    
+    use_bwd = args.use_bwd
 
     assert seqlen % world_size == 0
     assert d % 8 == 0
@@ -66,13 +78,13 @@ if __name__ == "__main__":
 
     # Prepare inputs
     q = torch.randn(
-        batch_size, seqlen, nheads, d, device=device, dtype=dtype, requires_grad=True
+        batch_size, seqlen, nheads, d, device=device, dtype=dtype, requires_grad=True if use_bwd else False
     )
     k = torch.randn(
-        batch_size, seqlen, nheads, d, device=device, dtype=dtype, requires_grad=True
+        batch_size, seqlen, nheads, d, device=device, dtype=dtype, requires_grad=True if use_bwd else False 
     )
     v = torch.randn(
-        batch_size, seqlen, nheads, d, device=device, dtype=dtype, requires_grad=True
+        batch_size, seqlen, nheads, d, device=device, dtype=dtype, requires_grad=True if use_bwd else False
     )
     dout = torch.randn(batch_size, seqlen, nheads, d, device=device, dtype=dtype)
 
@@ -84,7 +96,7 @@ if __name__ == "__main__":
     # prepare process group for hybrid sequence parallelism
     use_ring_low_dim = True
 
-    sp_ulysses_degree = 2
+    sp_ulysses_degree = args.sp_ulysses_degree if args.sp_ulysses_degree is not None else world_size
     sp_ring_degree = world_size // sp_ulysses_degree
 
     print(
@@ -97,17 +109,22 @@ if __name__ == "__main__":
     local_q = EXTRACT_FUNC_DICT[ring_impl_type](
         q, rank, world_size=world_size, rd=sp_ring_degree, ud=sp_ulysses_degree
     ).detach().clone()
-    local_q.requires_grad = True
+
 
     local_k = EXTRACT_FUNC_DICT[ring_impl_type](
         k, rank, world_size=world_size, rd=sp_ring_degree, ud=sp_ulysses_degree
     ).detach().clone()
-    local_k.requires_grad = True
+
 
     local_v = EXTRACT_FUNC_DICT[ring_impl_type](
         v, rank, world_size=world_size, rd=sp_ring_degree, ud=sp_ulysses_degree
     ).detach().clone()
-    local_v.requires_grad = True
+
+    if use_bwd:
+        local_q.requires_grad = True
+        local_k.requires_grad = True
+        local_v.requires_grad = True
+
     usp_attn = LongContextAttention(ring_impl_type=ring_impl_type, attn_type=FlashAttentionImpl.FA)
 
     if rank == 0:
@@ -121,6 +138,7 @@ if __name__ == "__main__":
     dropout_mask = None
 
     print(f"before usp attn forward: {local_q.shape} {local_k.shape} {local_v.shape}")
+
     # usp attn forward
     local_out = usp_attn(
         local_q,
@@ -140,11 +158,17 @@ if __name__ == "__main__":
         dout, rank, world_size=world_size, rd=sp_ring_degree, ud=sp_ulysses_degree
     ).detach().clone()
 
+    
+    max_memory = torch.cuda.max_memory_allocated(device) / (1024 * 1024)  # Convert to MB
+    print(f"[Rank#{rank}] Maximum GPU memory used: {max_memory:.2f} MB")
+    torch.cuda.reset_peak_memory_stats(device)  # Reset stats
+
+
     if rank == 0:
         print("#" * 30)
         print("# ds-ulysses backward:")
         print("#" * 30)
-
+    
     # usp attn backward
     if use_bwd:
         local_out.backward(local_dout)

--- a/yunchang/comm/extract_local.py
+++ b/yunchang/comm/extract_local.py
@@ -54,4 +54,5 @@ EXTRACT_FUNC_DICT = {
     "basic": basic_extract_local,
     "strip": stripe_extract_local,
     "zigzag": zigzag_extract_local,
+    "basic_pytorch": basic_extract_local,
 }

--- a/yunchang/hybrid/attn_layer.py
+++ b/yunchang/hybrid/attn_layer.py
@@ -108,7 +108,7 @@ class LongContextAttention(torch.nn.Module):
             value_layer = SeqAllToAll4D.apply(
                 self.ulysses_pg, value, self.scatter_idx, self.gather_idx, self.use_sync
             )
-
+            
             out = self.ring_attn_fn(
                 query_layer,
                 key_layer,

--- a/yunchang/hybrid/utils.py
+++ b/yunchang/hybrid/utils.py
@@ -5,12 +5,14 @@ from yunchang.ring import (
     zigzag_ring_flash_attn_qkvpacked_func,
     stripe_flash_attn_func,
     stripe_flash_attn_qkvpacked_func,
+    ring_pytorch_attn_func,
 )
 
 RING_IMPL_DICT = {
     "basic": ring_flash_attn_func,
     "zigzag": zigzag_ring_flash_attn_func,
     "strip": stripe_flash_attn_func,
+    "basic_pytorch": ring_pytorch_attn_func,
 }
 
 RING_IMPL_QKVPACKED_DICT = {

--- a/yunchang/kernels/__init__.py
+++ b/yunchang/kernels/__init__.py
@@ -3,7 +3,8 @@ from .attention import (
     flash_attn_backward, 
     flash_attn3_func_forward, 
     flash_attn3_func_backward, 
-    torch_attn,
+    pytorch_attn_forward,
+    pytorch_attn_backward,
     HAS_FLASH_ATTN_HOPPER
 )
 from enum import Enum, auto
@@ -64,10 +65,15 @@ def select_flash_attn_impl(impl_type: FlashAttentionImpl, stage : str = "fwd-bwd
             raise ValueError(f"Unknown stage: {stage}")
 
     elif impl_type == FlashAttentionImpl.TORCH:
-        if stage == "fwd-bwd" or stage == "fwd-only":
-            return torch_attn
+        if stage == "fwd-only":
+            return pytorch_attn_forward
+        elif stage == "bwd-only":
+            return pytorch_attn_backward
+        elif stage == "fwd-bwd":
+            from yunchang.ring.ring_pytorch_attn import pytorch_attn_func
+            return pytorch_attn_func
         else:
-            raise ValueError(f"FlashAttentionImpl.TORCH: bwd-only is not supported")
+            raise ValueError(f"Unknown stage: {stage}")
     else:
         raise ValueError(f"Unknown flash attention implementation: {impl_type}")
 

--- a/yunchang/kernels/attention.py
+++ b/yunchang/kernels/attention.py
@@ -1,5 +1,6 @@
 from yunchang.globals import HAS_FLASH_ATTN, HAS_FLASH_ATTN_HOPPER
-
+import math
+import torch
 if HAS_FLASH_ATTN:
     import flash_attn
     from flash_attn.flash_attn_interface import _flash_attn_forward, _flash_attn_backward
@@ -16,26 +17,128 @@ else:
 
 import torch.nn.functional as F
 
-def torch_attn(q, k, v, dropout_p = 0.0, 
-            softmax_scale = None, 
-            causal=False, 
-            *args, **kwargs):
-    batch_size, seq_len, hs, hd = q.size()
-    query = q.view(batch_size, -1, hs, hd).transpose(1, 2)
-    key = k.view(batch_size, -1, hs, hd).transpose(1, 2)
-    value = v.view(batch_size, -1, hs, hd).transpose(1, 2)
 
-    # the output of sdp = (batch, num_heads, seq_len, head_dim)
-    # TODO: add support for attn.scale when we move to Torch 2.1
-    hidden_states = F.scaled_dot_product_attention(
-        query, key, value, dropout_p=dropout_p, is_causal=causal
-    )
+def pytorch_attn_forward(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    dropout_p=0.0,
+    softmax_scale=None,
+    causal=True,
+    window_size=(-1, -1),
+    softcap=None,
+    alibi_slopes=None,
+    return_softmax=False,
+):
+# def pytorch_attn_forward(
+#     q: torch.Tensor,
+#     k: torch.Tensor,
+#     v: torch.Tensor,
+#     softmax_scale,
+#     causal=True,
+# ):
+    # TODO(optimize) preprocess to reuse the original code
+    q = q.transpose(1, 2)
+    k = k.transpose(1, 2)
+    v = v.transpose(1, 2)
 
-    hidden_states = hidden_states.transpose(1, 2).reshape(
-        batch_size, -1, hs, hd
-    )
-    hidden_states = hidden_states.to(query.dtype)
-    return hidden_states,
+    if softmax_scale is None:
+        softmax_scale = q.shape[-1] ** (-0.5)
+    batch_size, nheads, seqlen, d = q.shape
+    S = torch.matmul(q, k.transpose(-2, -1)) * softmax_scale
+
+    if causal:
+        causal_mask = torch.triu(torch.ones(seqlen, seqlen, device=q.device, dtype=torch.bool), diagonal=1)
+        causal_mask = causal_mask.unsqueeze(0).unsqueeze(1).expand(batch_size, nheads, seqlen, seqlen)
+        S.masked_fill_(causal_mask, float('-inf'))
+
+    # Online softmax
+    S_max = torch.max(S, dim=-1, keepdim=True)[0]
+    exp_S = torch.exp(S - S_max)
+    exp_sum = torch.sum(exp_S, dim=-1, keepdim=True)
+    log_sum_exp = torch.log(exp_sum) + S_max
+    P = exp_S / exp_sum
+    O = torch.matmul(P, v)
+
+    # TODO(optimize) post process to reuse the original code
+    O = O.transpose(1, 2)
+
+    lse = log_sum_exp.squeeze(-1)
+    return O, lse
+
+# def pytorch_attn_backward(
+#     dout,
+#     q,
+#     k,
+#     v,
+#     out,
+#     softmax_lse,
+#     softmax_scale = None,
+#     causal=True,
+#     *args,
+#     **kwargs,
+# ):
+def pytorch_attn_backward(
+    dout,
+    q,
+    k,
+    v,
+    out,
+    softmax_lse,
+    block_dq_buffer=None,  # Add new parameters with default values
+    block_dk_buffer=None,
+    block_dv_buffer=None,
+    dropout_p=0.0,
+    softmax_scale=None,
+    bwd_causal=None,  # This will replace the original causal parameter
+    window_size=None,
+    softcap=None,
+    alibi_slopes=None,
+    deterministic=True,
+    rng_state=None,
+    *args,
+    **kwargs,
+):
+    # TODO() preprocess to reuse the original code
+    q = q.transpose(1, 2)
+    k = k.transpose(1, 2)
+    v = v.transpose(1, 2)
+    out = out.transpose(1, 2)
+    dout = dout.transpose(1, 2)
+
+    batch_size, nheads, seqlen, d = q.shape
+    if softmax_scale is None:
+        softmax_scale = q.shape[-1] ** (-0.5)
+    
+    # Recreate S and P from log_sum_exp
+    S = torch.matmul(q, k.transpose(-2, -1)) * softmax_scale
+    if bwd_causal:
+        causal_mask = torch.triu(torch.ones(seqlen, seqlen, device=q.device, dtype=torch.bool), diagonal=1)
+        S = S.masked_fill(causal_mask.unsqueeze(0).unsqueeze(1), float('-inf'))
+
+    P = torch.exp(S - softmax_lse.unsqueeze(-1))
+    # Step 1: Compute dV
+    dV = torch.matmul(P.transpose(-2, -1), dout)
+    # Step 2: Compute dP
+    dP = torch.matmul(dout, v.transpose(-2, -1))
+    # Step 3: Compute D
+    D = torch.sum(dout * out, dim=-1, keepdim=True)
+    # Step 4: Compute dS
+    dS = P * (dP - D)
+    # Apply causal mask to dS if is_causal is True
+    if bwd_causal:
+        dS = dS.masked_fill(causal_mask.unsqueeze(0).unsqueeze(1), 0)
+    # Step 5: Compute dQ
+    dQ = torch.matmul(dS, k) * softmax_scale
+    # Step 6: Compute dK
+    dK = torch.matmul(dS.transpose(-2, -1), q) * softmax_scale
+
+    # TODO() post process to reuse origina; code
+    dQ = dQ.transpose(1, 2)
+    dK = dK.transpose(1, 2)
+    dV = dV.transpose(1, 2)
+
+    return dQ, dK, dV
 
 def flash_attn_forward(q, k, v, 
         dropout_p = 0.0, 

--- a/yunchang/kernels/attention.py
+++ b/yunchang/kernels/attention.py
@@ -48,7 +48,7 @@ def flash_attn_forward(q, k, v,
     assert HAS_FLASH_ATTN, "FlashAttention is not available"
     if softmax_scale is None:
         softmax_scale = q.shape[-1] ** (-0.5)
-    if flash_attn.__version__ <= '2.6.3':
+    if flash_attn.__version__ < '2.6.3':
         block_out, _, _, _, _, block_lse, _, _ = _flash_attn_forward(
             q,
             k,
@@ -82,7 +82,7 @@ def flash_attn_backward(dout, q, k, v, out, softmax_lse, block_dq_buffer, block_
     if softmax_scale is None:
         softmax_scale = q.shape[-1] ** (-0.5)
     assert HAS_FLASH_ATTN
-    if flash_attn.__version__ <= '2.6.3':
+    if flash_attn.__version__ < '2.6.3':
         _flash_attn_backward(
             dout,
             q,

--- a/yunchang/ring/__init__.py
+++ b/yunchang/ring/__init__.py
@@ -23,3 +23,7 @@ from .stripe_flash_attn import (
     stripe_flash_attn_kvpacked_func,
     stripe_flash_attn_qkvpacked_func,
 )
+
+from .ring_pytorch_attn import (
+    ring_pytorch_attn_func,
+)

--- a/yunchang/ring/ring_flash_attn.py
+++ b/yunchang/ring/ring_flash_attn.py
@@ -32,18 +32,6 @@ def ring_flash_attn_forward(
             comm.commit()
 
         if not causal or step <= comm.rank:
-            # block_out, _, _, _, _, block_lse, _, _ = _flash_attn_forward(
-            #     q,
-            #     k,
-            #     v,
-            #     dropout_p,
-            #     softmax_scale,
-            #     causal=causal and step == 0,
-            #     window_size=window_size,
-            #     softcap=softcap,
-            #     alibi_slopes=alibi_slopes,
-            #     return_softmax=True and dropout_p > 0,
-            # )
             fn = select_flash_attn_impl(attn_type, stage="fwd-only")
             block_out, block_lse = fn(
                 q,

--- a/yunchang/ring/ring_pytorch_attn.py
+++ b/yunchang/ring/ring_pytorch_attn.py
@@ -1,0 +1,233 @@
+# adapted from https://github.com/huggingface/picotron/blob/main/picotron/context_parallel/context_parallel.py
+import math
+import torch
+import torch.nn.functional as F
+from typing import Any, Optional, Tuple
+from yunchang.kernels import select_flash_attn_impl, FlashAttentionImpl
+from .utils import RingComm
+
+def ring_pytorch_attn_func(
+    q,
+    k,
+    v,
+    dropout_p=0.0,
+    softmax_scale=None,
+    causal=False,
+    window_size=(-1, -1),
+    softcap=0.0,
+    alibi_slopes=None,
+    deterministic=False,
+    return_attn_probs=False,
+    group=None,
+    attn_type: FlashAttentionImpl = FlashAttentionImpl.FA,
+):
+# def ring_attention(process_group, q, k, v, sm_scale, is_causal):
+    return RingAttentionFunc.apply(group, q, k, v, softmax_scale, causal)
+
+class RingAttentionFunc(torch.autograd.Function):
+
+    @staticmethod
+    def forward(ctx, group, q, k, v, sm_scale, is_causal):
+        comm = RingComm(group)
+        #TODO(fmom): add flex attention
+        #TODO(fmom): add flash attention
+        #TODO(fmom): Find a better to save these tensors without cloning
+        k_og = k.clone()
+        v_og = v.clone()
+        out, lse = None, None
+        next_k, next_v = None, None
+
+        if sm_scale is None:
+            sm_scale = 1.0 / math.sqrt(q.size(-1))
+
+        for step in range(comm.world_size):
+            if step + 1 != comm.world_size:
+                next_k = comm.send_recv(k)
+                next_v = comm.send_recv(v)
+                comm.commit()
+
+            if not is_causal or step <= comm.rank:
+                block_out, block_lse  = ring_pytorch_attn_forward(
+                    q, k, v, softmax_scale = sm_scale, causal = is_causal and step == 0
+                )
+                out, lse = update_out_and_lse(out, lse, block_out, block_lse)
+                
+            if step + 1 != comm.world_size:
+                comm.wait()
+                k = next_k
+                v = next_v
+
+        out = out.to(q.dtype)
+        ctx.save_for_backward(q, k_og, v_og, out, lse.squeeze(-1))
+        ctx.sm_scale = sm_scale
+        ctx.is_causal = is_causal
+        ctx.group = group
+        return out
+
+    @staticmethod
+    def backward(ctx, dout, *args):
+
+        q, k, v, out, softmax_lse = ctx.saved_tensors
+        sm_scale = ctx.sm_scale
+        is_causal = ctx.is_causal
+
+        kv_comm = RingComm(ctx.group)
+        d_kv_comm = RingComm(ctx.group)
+
+        dq, dk, dv = None, None, None
+        next_dk, next_dv = None, None
+        
+        block_dq_buffer = torch.empty(q.shape, dtype=q.dtype, device=q.device)
+        block_dk_buffer = torch.empty(k.shape, dtype=k.dtype, device=k.device)
+        block_dv_buffer = torch.empty(v.shape, dtype=v.dtype, device=v.device)
+
+        next_dk, next_dv = None, None
+        next_k, next_v = None, None
+
+        for step in range(kv_comm.world_size):
+            if step + 1 != kv_comm.world_size:
+                next_k = kv_comm.send_recv(k)
+                next_v = kv_comm.send_recv(v)
+                kv_comm.commit()
+
+            if step <= kv_comm.rank or not is_causal:
+                bwd_causal = is_causal and step == 0
+
+                block_dq_buffer, block_dk_buffer, block_dv_buffer = ring_pytorch_attn_backward(
+                    dout, q, k, v, out, softmax_lse = softmax_lse, softmax_scale = sm_scale, causal = bwd_causal
+                )
+
+                if dq is None:
+                    dq = block_dq_buffer.to(torch.float32)
+                    dk = block_dk_buffer.to(torch.float32)
+                    dv = block_dv_buffer.to(torch.float32)
+                else:
+                    dq += block_dq_buffer
+                    d_kv_comm.wait()
+                    dk = block_dk_buffer + next_dk
+                    dv = block_dv_buffer + next_dv
+            elif step != 0:
+                d_kv_comm.wait()
+                dk = next_dk
+                dv = next_dv
+
+            if step + 1 != kv_comm.world_size:
+                kv_comm.wait()
+                k = next_k
+                v = next_v
+
+            next_dk = d_kv_comm.send_recv(dk)
+            next_dv = d_kv_comm.send_recv(dv)
+            d_kv_comm.commit()
+
+        d_kv_comm.wait()
+
+        return dq, next_dk, next_dv, None, None
+
+def ring_pytorch_attn_forward(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    softmax_scale,
+    dropout_p=0,
+    causal=True,
+    window_size=(-1, -1),
+    softcap=0.0,
+    alibi_slopes=None,
+    deterministic=False,
+    attn_type: FlashAttentionImpl = None,
+):
+# def ring_attention_forward(q, k, v, sm_scale, is_causal):
+    batch_size, nheads, seqlen, d = q.shape
+    S = torch.matmul(q, k.transpose(-2, -1)) * softmax_scale
+
+    if causal:
+        causal_mask = torch.triu(torch.ones(seqlen, seqlen, device=q.device, dtype=torch.bool), diagonal=1)
+        causal_mask = causal_mask.unsqueeze(0).unsqueeze(1).expand(batch_size, nheads, seqlen, seqlen)
+        S.masked_fill_(causal_mask, float('-inf'))
+
+    # Online softmax
+    S_max = torch.max(S, dim=-1, keepdim=True)[0]
+    exp_S = torch.exp(S - S_max)
+    exp_sum = torch.sum(exp_S, dim=-1, keepdim=True)
+    log_sum_exp = torch.log(exp_sum) + S_max
+    P = exp_S / exp_sum
+    O = torch.matmul(P, v)
+    return O, log_sum_exp.squeeze(-1)
+
+def ring_pytorch_attn_backward(
+    dout,
+    q,
+    k,
+    v,
+    out,
+    softmax_lse,
+    softmax_scale,
+    dropout_p=0,
+    causal=True,
+    window_size=(-1, -1),
+    softcap=0.0,
+    alibi_slopes=None,
+    deterministic=False,
+    attn_type: FlashAttentionImpl = FlashAttentionImpl.TORCH,
+):
+# def ring_attention_backward(dO, Q, K, V, O, softmax_lse, sm_scale, is_causal):
+    batch_size, nheads, seqlen, d = q.shape
+    if softmax_scale is None:
+        softmax_scale = 1.0 / math.sqrt(q.size(-1))
+    
+    # Recreate S and P from log_sum_exp
+    S = torch.matmul(q, k.transpose(-2, -1)) * softmax_scale
+    if causal:
+        causal_mask = torch.triu(torch.ones(seqlen, seqlen, device=q.device, dtype=torch.bool), diagonal=1)
+        S = S.masked_fill(causal_mask.unsqueeze(0).unsqueeze(1), float('-inf'))
+
+    P = torch.exp(S - softmax_lse.unsqueeze(-1))
+    # Step 1: Compute dV
+    dV = torch.matmul(P.transpose(-2, -1), dout)
+    # Step 2: Compute dP
+    dP = torch.matmul(dout, v.transpose(-2, -1))
+    # Step 3: Compute D
+    D = torch.sum(dout * out, dim=-1, keepdim=True)
+    # Step 4: Compute dS
+    dS = P * (dP - D)
+    # Apply causal mask to dS if is_causal is True
+    if causal:
+        dS = dS.masked_fill(causal_mask.unsqueeze(0).unsqueeze(1), 0)
+    # Step 5: Compute dQ
+    dQ = torch.matmul(dS, k) * softmax_scale
+    # Step 6: Compute dK
+    dK = torch.matmul(dS.transpose(-2, -1), q) * softmax_scale
+    return dQ, dK, dV
+
+def update_out_and_lse(
+    out: Optional[torch.Tensor],
+    lse: Optional[torch.Tensor],
+    block_out: torch.Tensor,
+    block_lse: torch.Tensor,
+    slice_: Optional[Any] = None
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    
+    def _update(current_out, current_lse):
+        # new_lse = lse + torch.log(1 + torch.exp(block_lse - lse))
+        # torch.exp(lse - new_lse) * out + torch.exp(block_lse - new_lse) * block_out
+        # For additional context and discussion, please refer to:
+        # https://github.com/zhuzilin/ring-flash-attention/pull/34#issuecomment-2076126795
+        current_out = current_out - F.sigmoid(block_lse - current_lse) * (current_out - block_out)
+        current_lse = current_lse - F.logsigmoid(current_lse - block_lse)
+        return current_out, current_lse
+    
+    block_out = block_out.to(torch.float32)
+    block_lse = block_lse.unsqueeze(dim=-1)
+
+    if out is None:
+        if slice_ is not None:
+            raise RuntimeError("first update_out_and_lse should not pass slice_ args")
+        return block_out, block_lse
+
+    if slice_ is not None:
+        out[slice_], lse[slice_] = _update(out[slice_], lse[slice_])
+    else:
+        out, lse = _update(out, lse)
+        
+    return out, lse

--- a/yunchang/ring/utils.py
+++ b/yunchang/ring/utils.py
@@ -92,6 +92,7 @@ class RingComm:
     ) -> torch.Tensor:
         if recv_tensor is None:
             res = torch.empty_like(to_send)
+            # print(f"send_recv: empty_like {to_send.shape}")
         else:
             res = recv_tensor
 


### PR DESCRIPTION
Before, if you do not install flash_attn, you can not use ring attention.
Now we use pytorch ring attention implementations for fwd and bwd.