### PR TITLE
feat: support flashinfer for ring attention

### DIFF
--- a/test/test_hybrid_attn.py
+++ b/test/test_hybrid_attn.py
@@ -167,11 +167,12 @@ if __name__ == "__main__":
                                     attn_type=attn_impl_map[args.attn_impl],
                                     attn_processor=attn_processor)
 
-    if not args.sparse_sage_tune_mode:
-        saved_state_dict = torch.load(args.sparse_sage_tune_path + f".rank{dist.get_rank()}")
-        load_sparse_attention_state_dict(usp_attn, saved_state_dict, multigpu=True, verbose=True)
-    else:
-        os.environ["sparse_sage_tune_mode"] = "1"
+    if args.attn_impl == 'sparse_sage':
+        if not args.sparse_sage_tune_mode:
+            saved_state_dict = torch.load(args.sparse_sage_tune_path + f".rank{dist.get_rank()}")
+            load_sparse_attention_state_dict(usp_attn, saved_state_dict, multigpu=True, verbose=True)
+        else:
+            os.environ["sparse_sage_tune_mode"] = "1"
 
     if rank == 0:
         print("#" * 30)

--- a/test/test_hybrid_attn.py
+++ b/test/test_hybrid_attn.py
@@ -23,12 +23,12 @@ def parse_args():
     parser.add_argument('--sp_ulysses_degree', type=int, default=None,
                       help='sp_ulysses_degree (default: world_size)')
     parser.add_argument('--ring_impl_type', type=str, default='basic',
-                      choices=['basic', 'zigzag'],
+                      choices=['basic', 'zigzag', 'basic_flashinfer'],
                       help='ring implementation type (default: basic)')
     parser.add_argument('--causal', action='store_true',
                       help='whether to use causal attention (default: False)')
     parser.add_argument('--attn_impl', type=str, default='torch',
-                      choices=['torch', 'fa', 'fa3', 'sage_fp16', 'sage_fp8', 'sparse_sage'],
+                      choices=['torch', 'fa', 'fa3', 'flashinfer', 'sage_fp16', 'sage_fp8', 'sparse_sage'],
                       help='attention implementation type (default: torch)')
     parser.add_argument('--sparse_sage_l1', type=float, default=0.07,
                       help='l1 for sparse sage attention (default: 0.07)')
@@ -150,6 +150,7 @@ if __name__ == "__main__":
         'torch': AttnType.TORCH,
         'fa': AttnType.FA,
         'fa3': AttnType.FA3,
+        'flashinfer': AttnType.FLASHINFER,
         'sage_fp16': AttnType.SAGE_FP16,
         'sage_fp8': AttnType.SAGE_FP8,
         'sparse_sage': AttnType.SPARSE_SAGE

--- a/yunchang/comm/extract_local.py
+++ b/yunchang/comm/extract_local.py
@@ -55,4 +55,5 @@ EXTRACT_FUNC_DICT = {
     "strip": stripe_extract_local,
     "zigzag": zigzag_extract_local,
     "basic_pytorch": basic_extract_local,
+    "basic_flashinfer": basic_extract_local,
 }

--- a/yunchang/globals.py
+++ b/yunchang/globals.py
@@ -96,6 +96,12 @@ except ImportError:
     HAS_FLASH_ATTN_HOPPER = False
 
 try:
+    from flashinfer.prefill import single_prefill_with_kv_cache
+    HAS_FLASHINFER = True
+except ImportError:
+    HAS_FLASHINFER = False
+
+try:
     import sageattention
     HAS_SAGE_ATTENTION = True
 except ImportError:

--- a/yunchang/hybrid/utils.py
+++ b/yunchang/hybrid/utils.py
@@ -6,6 +6,8 @@ from yunchang.ring import (
     stripe_flash_attn_func,
     stripe_flash_attn_qkvpacked_func,
     ring_pytorch_attn_func,
+    ring_flashinfer_attn_func,
+    ring_flashinfer_attn_qkvpacked_func,
 )
 
 RING_IMPL_DICT = {
@@ -13,10 +15,12 @@ RING_IMPL_DICT = {
     "zigzag": zigzag_ring_flash_attn_func,
     "strip": stripe_flash_attn_func,
     "basic_pytorch": ring_pytorch_attn_func,
+    "basic_flashinfer": ring_flashinfer_attn_func
 }
 
 RING_IMPL_QKVPACKED_DICT = {
     "basic": ring_flash_attn_qkvpacked_func,
     "zigzag": zigzag_ring_flash_attn_qkvpacked_func,
     "strip": stripe_flash_attn_qkvpacked_func,
+    "basic_flashinfer": ring_flashinfer_attn_qkvpacked_func,
 }

--- a/yunchang/ring/__init__.py
+++ b/yunchang/ring/__init__.py
@@ -27,3 +27,9 @@ from .stripe_flash_attn import (
 from .ring_pytorch_attn import (
     ring_pytorch_attn_func,
 )
+
+from .ring_flashinfer_attn import (
+    ring_flashinfer_attn_func,
+    ring_flashinfer_attn_kvpacked_func,
+    ring_flashinfer_attn_qkvpacked_func,
+)

--- a/yunchang/ring/ring_flashinfer_attn.py
+++ b/yunchang/ring/ring_flashinfer_attn.py
@@ -59,7 +59,6 @@ def ring_flashinfer_attn_forward(
             v = next_v
 
     out = out.to(q.dtype)
-    print("shape:", lse.shape)
     lse = lse.squeeze(dim=-1).transpose(1, 2)
     return out, lse
 

--- a/yunchang/ring/ring_flashinfer_attn.py
+++ b/yunchang/ring/ring_flashinfer_attn.py
@@ -1,0 +1,325 @@
+import torch
+import torch.distributed as dist
+
+# from flash_attn.flash_attn_interface import _flash_attn_forward, _flash_attn_backward
+from .utils import RingComm, update_out_and_lse
+from yunchang.kernels import select_flash_attn_impl, AttnType
+import torch.utils.cpp_extension as torch_cpp_ext
+
+torch_cpp_ext._get_cuda_arch_flags()
+
+
+def ring_flashinfer_attn_forward(
+    process_group,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    softmax_scale,
+    dropout_p=0,
+    causal=True,
+    window_size=(-1, -1),
+    softcap=0.0,
+    alibi_slopes=None,
+    deterministic=False,
+    attn_type: AttnType = AttnType.FLASHINFER,
+    attn_processor=None,
+):
+    comm = RingComm(process_group)
+
+    out = None
+    lse = None
+
+    next_k, next_v = None, None
+
+    for step in range(comm.world_size):
+        if step + 1 != comm.world_size:
+            next_k: torch.Tensor = comm.send_recv(k)
+            next_v: torch.Tensor = comm.send_recv(v)
+            comm.commit()
+
+        if not causal or step <= comm.rank:
+            fn = select_flash_attn_impl(attn_type, stage="fwd-only", attn_processor=attn_processor)
+            block_out, block_lse = fn(
+                q,
+                k,
+                v,
+                dropout_p=dropout_p,
+                softmax_scale=softmax_scale,
+                causal=causal and step == 0,
+                window_size=window_size,
+                softcap=softcap,
+                alibi_slopes=alibi_slopes,
+                return_softmax=True and dropout_p > 0,
+            )
+            out, lse = update_out_and_lse(out, lse, block_out, block_lse)
+
+        if step + 1 != comm.world_size:
+            comm.wait()
+            k = next_k
+            v = next_v
+
+    out = out.to(q.dtype)
+    print("shape:", lse.shape)
+    lse = lse.squeeze(dim=-1).transpose(1, 2)
+    return out, lse
+
+
+def ring_flashinfer_attn_backward(
+    process_group,
+    dout,
+    q,
+    k,
+    v,
+    out,
+    softmax_lse,
+    softmax_scale,
+    dropout_p=0,
+    causal=True,
+    window_size=(-1, -1),
+    softcap=0.0,
+    alibi_slopes=None,
+    deterministic=False,
+    attn_type: AttnType = AttnType.FLASHINFER,
+):
+    kv_comm = RingComm(process_group)
+    d_kv_comm = RingComm(process_group)
+    dq, dk, dv = None, None, None
+    next_dk, next_dv = None, None
+
+    block_dq_buffer = torch.empty(q.shape, dtype=q.dtype, device=q.device)
+    block_dk_buffer = torch.empty(k.shape, dtype=k.dtype, device=k.device)
+    block_dv_buffer = torch.empty(v.shape, dtype=v.dtype, device=v.device)
+
+    next_dk, next_dv = None, None
+    next_k, next_v = None, None
+
+    for step in range(kv_comm.world_size):
+        if step + 1 != kv_comm.world_size:
+            next_k = kv_comm.send_recv(k)
+            next_v = kv_comm.send_recv(v)
+            kv_comm.commit()
+        if step <= kv_comm.rank or not causal:
+            bwd_causal = causal and step == 0
+            fn = select_flash_attn_impl(attn_type, stage="bwd-only")
+            fn(
+                dout,
+                q,
+                k,
+                v,
+                out,
+                softmax_lse,
+                block_dq_buffer,
+                block_dk_buffer,
+                block_dv_buffer,
+                dropout_p,
+                softmax_scale,
+                bwd_causal,
+                window_size,
+                softcap,
+                alibi_slopes,
+                deterministic,
+                rng_state=None,
+            )
+
+            if dq is None:
+                dq = block_dq_buffer.to(torch.float32)
+                dk = block_dk_buffer.to(torch.float32)
+                dv = block_dv_buffer.to(torch.float32)
+            else:
+                dq += block_dq_buffer
+                d_kv_comm.wait()
+                dk = block_dk_buffer + next_dk
+                dv = block_dv_buffer + next_dv
+        elif step != 0:
+            d_kv_comm.wait()
+            dk = next_dk
+            dv = next_dv
+
+        if step + 1 != kv_comm.world_size:
+            kv_comm.wait()
+            k = next_k
+            v = next_v
+
+        next_dk = d_kv_comm.send_recv(dk)
+        next_dv = d_kv_comm.send_recv(dv)
+        d_kv_comm.commit()
+
+    d_kv_comm.wait()
+
+    return dq.to(torch.bfloat16), next_dk.to(q.dtype), next_dv.to(q.dtype)
+
+
+WORKSPACE_BUFFER = None
+PREFILL_WRAPPER = None
+
+
+class RingFlashInferAttnFunc(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx,
+        q,
+        k,
+        v,
+        dropout_p,
+        softmax_scale,
+        causal,
+        window_size,
+        softcap,
+        alibi_slopes,
+        deterministic,
+        return_softmax,
+        group,
+        attn_type,
+        attn_processor,
+    ):
+        if softmax_scale is None:
+            softmax_scale = q.shape[-1] ** (-0.5)
+
+        assert alibi_slopes is None
+        k = k.contiguous()
+        v = v.contiguous()
+        out, softmax_lse = ring_flashinfer_attn_forward(
+            group,
+            q,
+            k,
+            v,
+            softmax_scale=softmax_scale,
+            dropout_p=dropout_p,
+            causal=causal,
+            window_size=window_size,
+            softcap=softcap,
+            alibi_slopes=alibi_slopes,
+            deterministic=False,
+            attn_type=attn_type,
+            attn_processor=attn_processor,
+        )
+        # this should be out_padded
+        ctx.save_for_backward(q, k, v, out, softmax_lse)
+        ctx.dropout_p = dropout_p
+        ctx.softmax_scale = softmax_scale
+        ctx.causal = causal
+        ctx.window_size = window_size
+        ctx.softcap = softcap
+        ctx.alibi_slopes = alibi_slopes
+        ctx.deterministic = deterministic
+        ctx.group = group
+        ctx.attn_type = attn_type
+        ctx.attn_processor = attn_processor
+        return out if not return_softmax else (out, softmax_lse, None)
+
+    @staticmethod
+    def backward(ctx, dout, *args):
+        q, k, v, out, softmax_lse = ctx.saved_tensors
+        dq, dk, dv = ring_flashinfer_attn_backward(
+            ctx.group,
+            dout,
+            q,
+            k,
+            v,
+            out,
+            softmax_lse,
+            softmax_scale=ctx.softmax_scale,
+            dropout_p=ctx.dropout_p,
+            causal=ctx.causal,
+            window_size=ctx.window_size,
+            softcap=ctx.softcap,
+            alibi_slopes=ctx.alibi_slopes,
+            deterministic=ctx.deterministic,
+            attn_type=ctx.attn_type,
+        )
+        return dq, dk, dv, None, None, None, None, None, None, None, None, None, None
+
+
+def ring_flashinfer_attn_qkvpacked_func(
+    qkv,
+    dropout_p=0.0,
+    softmax_scale=None,
+    causal=False,
+    window_size=(-1, -1),
+    softcap=0.0,
+    alibi_slopes=None,
+    deterministic=False,
+    return_attn_probs=False,
+    group=None,
+    attn_type: AttnType = AttnType.FLASHINFER,
+):
+    return RingFlashInferAttnFunc.apply(
+        qkv[:, :, 0],
+        qkv[:, :, 1],
+        qkv[:, :, 2],
+        dropout_p,
+        softmax_scale,
+        causal,
+        window_size,
+        softcap,
+        alibi_slopes,
+        deterministic,
+        return_attn_probs,
+        group,
+        attn_type,
+    )
+
+
+def ring_flashinfer_attn_kvpacked_func(
+    q,
+    kv,
+    dropout_p=0.0,
+    softmax_scale=None,
+    causal=False,
+    window_size=(-1, -1),
+    softcap=0.0,
+    alibi_slopes=None,
+    deterministic=False,
+    return_attn_probs=False,
+    group=None,
+    attn_type: AttnType = AttnType.FLASHINFER,
+):
+    return RingFlashInferAttnFunc.apply(
+        q,
+        kv[:, :, 0],
+        kv[:, :, 1],
+        dropout_p,
+        softmax_scale,
+        causal,
+        window_size,
+        softcap,
+        alibi_slopes,
+        deterministic,
+        return_attn_probs,
+        group,
+        attn_type,
+    )
+
+
+def ring_flashinfer_attn_func(
+    q,
+    k,
+    v,
+    dropout_p=0.0,
+    softmax_scale=None,
+    causal=False,
+    window_size=(-1, -1),
+    softcap=0.0,
+    alibi_slopes=None,
+    deterministic=False,
+    return_attn_probs=False,
+    group=None,
+    attn_type: AttnType = AttnType.FLASHINFER,
+    attn_processor=None,
+):
+    return RingFlashInferAttnFunc.apply(
+        q,
+        k,
+        v,
+        dropout_p,
+        softmax_scale,
+        causal,
+        window_size,
+        softcap,
+        alibi_slopes,
+        deterministic,
+        return_attn_probs,
+        group,
+        attn_type,
+        attn_processor,
+    )


### PR DESCRIPTION
Use flashinfer's single_prefill_with_kv_cache to compute attention output and lse
- test command
  ```bash
  torchrun --nproc-per-node 8 test/test_hybrid_attn.py \
      --seqlen 4096 \
      --sp_ulysses_degree 2 \
      --ring_impl_type basic_flashinfer \
      --attn_impl flashinfer
  ```
- set environment variable `TORCH_CUDA_ARCH_LIST` according to your cuda arch if the program fails with `RuntimeError: FlashInfer requires sm75+`
  ```bash
  export TORCH_CUDA_ARCH_LIST='8.0 8.9 9.0+PTX'
  ```
