### PR TITLE
Add an option for using a triton kernel for sageattention

### DIFF
--- a/test/test_hybrid_attn.py
+++ b/test/test_hybrid_attn.py
@@ -28,7 +28,7 @@ def parse_args():
     parser.add_argument('--causal', action='store_true',
                       help='whether to use causal attention (default: False)')
     parser.add_argument('--attn_impl', type=str, default='torch',
-                      choices=['torch', 'fa', 'fa3', 'flashinfer', 'sage_fp16', 'sage_fp8', 'sparse_sage'],
+                      choices=['torch', 'fa', 'fa3', 'flashinfer', 'sage_fp16', 'sage_fp16_triton', 'sage_fp8', 'sparse_sage'],
                       help='attention implementation type (default: torch)')
     parser.add_argument('--sparse_sage_l1', type=float, default=0.07,
                       help='l1 for sparse sage attention (default: 0.07)')
@@ -152,6 +152,7 @@ if __name__ == "__main__":
         'fa3': AttnType.FA3,
         'flashinfer': AttnType.FLASHINFER,
         'sage_fp16': AttnType.SAGE_FP16,
+        'sage_fp16_triton': AttnType.SAGE_FP16_TRITON,
         'sage_fp8': AttnType.SAGE_FP8,
         'sparse_sage': AttnType.SPARSE_SAGE
     }

--- a/yunchang/kernels/__init__.py
+++ b/yunchang/kernels/__init__.py
@@ -31,6 +31,7 @@ class AttnType(Enum):
     FLASHINFER = "flashinfer"
     TORCH = "torch"
     SAGE_FP16 = "sage_fp16"
+    SAGE_FP16_TRITON = "sage_fp16_triton"
     SAGE_FP8 = "sage_fp8"
     SPARSE_SAGE = "sparse_sage"
 
@@ -108,6 +109,19 @@ def select_flash_attn_impl(impl_type: AttnType, stage : str = "fwd-bwd", attn_pr
             return partial(
                 sageattention.sageattn_qk_int8_pv_fp16_cuda, 
                 pv_accum_dtype="fp32",
+                tensor_layout="NHD",
+                return_lse=True,
+            )
+        else:
+            raise ValueError(f"Unknown/Unsupported stage: {stage}")
+
+    elif impl_type == AttnType.SAGE_FP16_TRITON:
+        if not HAS_SAGE_ATTENTION:
+            raise ImportError("SageAttention is not available!")
+
+        if stage == "fwd-only":
+            return partial(
+                sageattention.sageattn_qk_int8_pv_fp16_triton,
                 tensor_layout="NHD",
                 return_lse=True,
             )


### PR DESCRIPTION
`sageattn_qk_int8_pv_fp16_triton` is faster than the cuda version on sm_86, and also can be useful if compiled cuda kernels aren't available.