### PR TITLE
fix import flashinfer error on AMD GPUs

### DIFF
--- a/yunchang/ring/ring_flashinfer_attn.py
+++ b/yunchang/ring/ring_flashinfer_attn.py
@@ -4,9 +4,11 @@ import torch.distributed as dist
 # from flash_attn.flash_attn_interface import _flash_attn_forward, _flash_attn_backward
 from .utils import RingComm, update_out_and_lse
 from yunchang.kernels import select_flash_attn_impl, AttnType
+from yunchang.globals import HAS_FLASHINFER
 import torch.utils.cpp_extension as torch_cpp_ext
 
-torch_cpp_ext._get_cuda_arch_flags()
+if HAS_FLASHINFER:
+    torch_cpp_ext._get_cuda_arch_flags()
 
 
 def ring_flashinfer_attn_forward(


### PR DESCRIPTION
Getting CUDA arch flags raises error during importing flashinfer on AMD GPUs. As flashinfer is not officially supported on AMD platform, just disable it when flashinfer is not installed.