### PR TITLE
[bugfix] correct the operator alias in attention.py

### DIFF
--- a/yunchang/kernels/attention.py
+++ b/yunchang/kernels/attention.py
@@ -2,16 +2,14 @@ import math
 from typing import Optional, Tuple
 
 import torch
-from torch.ops.aten import (
-    _scaled_dot_product_flash_attention,
-    _scaled_dot_product_efficient_attention
-)
+_scaled_dot_product_flash_attention = torch.ops.aten._scaled_dot_product_flash_attention
+_scaled_dot_product_efficient_attention = torch.ops.aten._scaled_dot_product_efficient_attention
 
 # Apply Moore Threads PyTorch Patches. It will not interfere CUDA setup if you are
 # not running in Moore Threads's environment.
 try:
     import torch_musa
-    from torch.ops.aten import _scaled_dot_product_attention_flash_musa as _scaled_dot_product_flash_attention
+    _scaled_dot_product_flash_attention = torch.ops.aten._scaled_dot_product_attention_flash_musa
     # The efficient operator hasn't been implemented yet
     _scaled_dot_product_efficient_attention = None
 except ModuleNotFoundError:


### PR DESCRIPTION
# Description

In previous patch (https://github.com/feifeibear/long-context-attention/pull/152), I made a mistake which leads to a `ModuleNotFoundError` when loading `attention.py`. This issue dues to the dynamical loading mechanism of PyTorch--`torch.ops` is not a module which cannot be imported. These operator are loaded dynamically when the processing starts. We can only treat operators as some `variables`.

Really sorry for bring troubles to you. This thing reminds that I should never use only human brain as a debugger or a compiler. @feifeibear 

Please let me apologise for this stupid mistake!

<img width="522" height="48" alt="Screenshot_20250718_192108" src="https://github.com/user-attachments/assets/f6b328fc-f091-452f-9b80-77efeca22c8c" />

# Risks

* None