### PR TITLE
fix: use <= instead of < for flash_attn 2.6.3 version check

### DIFF
--- a/yunchang/kernels/attention.py
+++ b/yunchang/kernels/attention.py
@@ -173,7 +173,7 @@ def flash_attn_forward(q, k, v,
     assert HAS_FLASH_ATTN, "FlashAttention is not available"
     if softmax_scale is None:
         softmax_scale = q.shape[-1] ** (-0.5)
-    if flash_attn.__version__ < '2.6.3':
+    if flash_attn.__version__ <= '2.6.3':
         block_out, _, _, _, _, block_lse, _, _ = _flash_attn_forward(
             q,
             k,
@@ -207,7 +207,7 @@ def flash_attn_backward(dout, q, k, v, out, softmax_lse, block_dq_buffer, block_
     if softmax_scale is None:
         softmax_scale = q.shape[-1] ** (-0.5)
     assert HAS_FLASH_ATTN
-    if flash_attn.__version__ < '2.6.3':
+    if flash_attn.__version__ <= '2.6.3':
         _flash_attn_backward(
             dout,
             q,


### PR DESCRIPTION
flash_attn==2.6.3 uses the old window_size API, but the strict < comparison incorrectly routes it to the new window_size_left/window_size_right path, causing a TypeError at runtime.

Fix both flash_attn_forward and flash_attn_backward to use <= so that version 2.6.3 is correctly handled by the legacy API branch.

Fixes #158